### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/setaleablaze/dc424732-a3df-4d2a-a776-5e16c11819dd/cedd8b9b-4ffc-4ccd-b29b-8229e757e0f1/_apis/work/boardbadge/3f9fe6a9-25ea-4680-b6a3-30e8ef7a894c)](https://dev.azure.com/setaleablaze/dc424732-a3df-4d2a-a776-5e16c11819dd/_boards/board/t/cedd8b9b-4ffc-4ccd-b29b-8229e757e0f1/Microsoft.RequirementCategory)
 [![Version](https://img.shields.io/npm/v/@docker/actions-toolkit?label=version&logo=npm&style=flat-square)](https://www.npmjs.com/package/@docker/actions-toolkit)
 [![Downloads](https://img.shields.io/npm/dw/@docker/actions-toolkit?logo=npm&style=flat-square)](https://www.npmjs.com/package/@docker/actions-toolkit)
 [![Build workflow](https://img.shields.io/github/actions/workflow/status/docker/actions-toolkit/build.yml?label=build&logo=github&style=flat-square)](https://github.com/docker/actions-toolkit/actions?workflow=build)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/setaleablaze/dc424732-a3df-4d2a-a776-5e16c11819dd/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.